### PR TITLE
updated makefile for rgbds 7.0 + nix automatic environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ gfx/pokedex/pokedex.2bpp: tools/gfx += --trim-whitespace
 gfx/pokedex/pokedex_sgb.2bpp: tools/gfx += --trim-whitespace
 gfx/pokedex/question_mark.2bpp: rgbgfx += -Z
 gfx/pokedex/slowpoke.2bpp: tools/gfx += --trim-whitespace
-gfx/pokedex/question_mark.2bpp: rgbgfx += -h
+gfx/pokedex/question_mark.2bpp: rgbgfx += -Z
 
 gfx/pokegear/pokegear.2bpp: rgbgfx += -x2
 gfx/pokegear/pokegear_sprites.2bpp: tools/gfx += --trim-whitespace

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,77 @@
+{
+  description = "Johto Expansion Pack Romhack";
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-23.05;
+    flake-utils.url = github:numtide/flake-utils;
+  };
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    let
+      jepDerivation = { stdenv, src, pkgs,
+        make ? pkgs.gnumake,
+        gcc ? pkgs.gcc,
+        rgbds ? pkgs.rgbds,
+        files ? ["*.*gb*"],
+        # python3 ? pkgs.python3,
+      }: stdenv.mkDerivation rec {
+          src = ./.;
+          name = "jep-hack";
+          buildInputs = [ rgbds gcc make ];
+          installPhase = ''
+            shopt -s extglob
+            mkdir $out
+            ${builtins.concatStringsSep "\n" (map (item: 
+                if builtins.isList item && (builtins.length item == 2)
+                then "mv ${builtins.elemAt item 0} $out/${builtins.elemAt item 1}"
+                else "cp ${item}* $out"
+              ) files)}
+          '';
+        };
+    in flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs { inherit system; overlays = [self.overlays.default]; };
+      rgbds_7_0 =
+          pkgs.rgbds.overrideAttrs (oldAttrs: {
+            postPatch = ''
+              if [[ -d $PWD/src ]]; then
+                export PATH=$PWD/src:$PATH
+                chmod +x $PWD/src/*
+                patchShebangs $PWD
+              fi
+            '';
+            version = "0.7.0";
+            src = pkgs.fetchFromGitHub {
+              owner = "gbdev";
+              repo = "rgbds";
+              rev = "08f3e360c9525b65291db9cee66fc5eb6e4a45e4";
+              sha256 = "sha256-aktKJlwXpHpjSFxoz5wZJPGWZIcn4ax5iBP0GQEux78=";
+            };
+          });
+    in {
+      packages = {
+        default = pkgs.jep-hack;
+        jep-hack = pkgs.jep-hack;
+        rgbds_7_0 = rgbds_7_0;
+      };
+      devShells = {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rgbds_7_0
+            gcc
+            gnumake
+            sameboy
+            imagemagick
+          ];
+        };
+      };
+    }) // {
+      overlays = {
+        default = final: prev: {
+          jep-hack = final.callPackage jepDerivation {
+            files = [
+              ["pokecrystal.gbc" "johto-expansion-pak.gbc"]
+              ["pokecrystal.sym" "johto-expansion-pak.sym"]
+            ];
+          };
+        };
+      };
+    };
+}


### PR DESCRIPTION
Minor change to the makefile so it will work with RGBDS 0.7.0 (should still be backwards compatible with 0.6.1).

The flake file can be used to reproducibly set up the environment to build JEP, it requires the `nix` build tool which can be set up in WSL the following way:

https://xeiaso.net/blog/nix-flakes-4-wsl-2022-05-01/

Then either `nix develop`, or automatically if you use `direnv`, will enter a shell with the correct tools needed to build.

`nix build . -L` will build the rom without entering the environment and put the rom and sym in `./result`

`nix build github:ZetaNull/jep-hack -L` will do the above but without having to download the repository first

No pressure to use it but past the initial setup it makes changing rgbds versions or having reproducible build environments a lot easier, especially if working with multiple hacks that need different RGBDS versions :3 